### PR TITLE
refactor: extract game screen components

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -1,0 +1,36 @@
+// components/ActionButtons.js
+import React from 'react';
+import { View, Pressable, Text, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function ActionButtons({ isPlaying, canBuy, canSell, buyAll, sellAll, buttonScaleAnim }) {
+  if (!isPlaying) return null;
+
+  return (
+    <View style={gameStyles.actionSection}>
+      <Animated.View style={{ transform: [{ scale: buttonScaleAnim }] }}>
+        <Pressable
+          style={[gameStyles.actionButton, gameStyles.buyButton, { opacity: canBuy ? 1 : 0.5 }]}
+          onPress={buyAll}
+          disabled={!canBuy}
+        >
+          <Ionicons name="trending-up" size={20} color="#fff" />
+          <Text style={gameStyles.actionButtonText}>BUY ALL</Text>
+        </Pressable>
+      </Animated.View>
+
+      <Animated.View style={{ transform: [{ scale: buttonScaleAnim }] }}>
+        <Pressable
+          style={[gameStyles.actionButton, gameStyles.sellButton, { opacity: canSell ? 1 : 0.5 }]}
+          onPress={sellAll}
+          disabled={!canSell}
+        >
+          <Ionicons name="trending-down" size={20} color="#fff" />
+          <Text style={gameStyles.actionButtonText}>SELL ALL</Text>
+        </Pressable>
+      </Animated.View>
+    </View>
+  );
+}
+

--- a/components/GameControls.js
+++ b/components/GameControls.js
@@ -1,0 +1,45 @@
+// components/GameControls.js
+import React from 'react';
+import { View, Pressable, Text, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function GameControls({
+  isPlaying,
+  isPaused,
+  gameComplete,
+  startGame,
+  pauseGame,
+  goToMenu,
+  buttonScaleAnim,
+}) {
+  return (
+    <View style={gameStyles.controlSection}>
+      {!isPlaying && !gameComplete && (
+        <Animated.View style={{ transform: [{ scale: buttonScaleAnim }] }}>
+          <Pressable style={gameStyles.controlButton} onPress={startGame}>
+            <Ionicons name="play" size={20} color="#fff" />
+            <Text style={gameStyles.controlButtonText}>
+              {isPaused ? 'Resume' : 'Start Game'}
+            </Text>
+          </Pressable>
+        </Animated.View>
+      )}
+
+      {isPlaying && (
+        <Animated.View style={{ transform: [{ scale: buttonScaleAnim }] }}>
+          <Pressable style={gameStyles.controlButton} onPress={pauseGame}>
+            <Ionicons name="pause" size={20} color="#fff" />
+            <Text style={gameStyles.controlButtonText}>Pause</Text>
+          </Pressable>
+        </Animated.View>
+      )}
+
+      <Pressable style={gameStyles.menuButton} onPress={goToMenu}>
+        <Ionicons name="home" size={20} color="#fff" />
+        <Text style={gameStyles.menuButtonText}>Menu</Text>
+      </Pressable>
+    </View>
+  );
+}
+

--- a/components/GameProgress.js
+++ b/components/GameProgress.js
@@ -1,0 +1,37 @@
+// components/GameProgress.js
+import React from 'react';
+import { View, Text, Animated } from 'react-native';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function GameProgress({ currentMonth, gameYears, monthName, isPlaying, pulseAnim, progressAnim, gameMode }) {
+  return (
+    <View style={gameStyles.progressSection}>
+      <Animated.Text
+        style={[
+          gameStyles.progressTitle,
+          { transform: [{ scale: isPlaying ? pulseAnim : 1 }] }
+        ]}
+      >
+        Year {Math.floor(currentMonth / 12) + 1} of {gameYears}
+      </Animated.Text>
+      <Text style={gameStyles.progressSubtitle}>
+        {monthName}
+        {gameMode === 'speedrun' && ' • 2x Speed'}
+      </Text>
+      <View style={gameStyles.progressBar}>
+        <Animated.View
+          style={[
+            gameStyles.progressFill,
+            {
+              width: progressAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: ['0%', '100%']
+              })
+            }
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+

--- a/components/MarketData.js
+++ b/components/MarketData.js
@@ -1,0 +1,96 @@
+// components/MarketData.js
+import React from 'react';
+import { View, Text, Animated } from 'react-native';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function MarketData({
+  gameMode,
+  stockMetadata,
+  priceAnimations,
+  monthlyChanges,
+  currentPrices,
+  formatPercentage,
+  formatCurrency,
+}) {
+  if (gameMode === 'diversified') {
+    return (
+      <View style={gameStyles.stocksSection}>
+        <Text style={gameStyles.sectionTitle}>Market Prices</Text>
+        <View style={gameStyles.stocksGrid}>
+          {Object.keys(stockMetadata).map(symbol => (
+            <Animated.View
+              key={symbol}
+              style={[
+                gameStyles.stockCard,
+                {
+                  transform: priceAnimations.current[symbol]
+                    ? [
+                        {
+                          translateY: priceAnimations.current[symbol].interpolate({
+                            inputRange: [-0.1, 0, 0.1],
+                            outputRange: [5, 0, -5],
+                          }),
+                        },
+                      ]
+                    : [],
+                },
+              ]}
+            >
+              <View style={gameStyles.stockHeader}>
+                <Text style={gameStyles.stockSymbol}>{symbol}</Text>
+                <Text
+                  style={[
+                    gameStyles.stockChange,
+                    { color: (monthlyChanges[symbol] || 0) >= 0 ? '#38ef7d' : '#ff6b6b' },
+                  ]}
+                >
+                  {formatPercentage(monthlyChanges[symbol] || 0)}
+                </Text>
+              </View>
+              <Text style={gameStyles.stockPrice}>
+                {formatCurrency(currentPrices[symbol] || 0)}
+              </Text>
+              <Text style={gameStyles.stockName}>
+                {stockMetadata[symbol].name}
+              </Text>
+            </Animated.View>
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <Animated.View
+      style={[
+        gameStyles.marketSection,
+        {
+          transform: priceAnimations.current.SP500
+            ? [
+                {
+                  translateY: priceAnimations.current.SP500.interpolate({
+                    inputRange: [-0.1, 0, 0.1],
+                    outputRange: [5, 0, -5],
+                  }),
+                },
+              ]
+            : [],
+        },
+      ]}
+    >
+      <Text style={gameStyles.sectionTitle}>S&P 500</Text>
+      <Text style={gameStyles.marketPrice}>
+        {formatCurrency(currentPrices.SP500 || 0)}
+      </Text>
+      <Text
+        style={[
+          gameStyles.marketChange,
+          { color: (monthlyChanges.SP500 || 0) >= 0 ? '#38ef7d' : '#ff6b6b' },
+        ]}
+      >
+        {formatPercentage(monthlyChanges.SP500 || 0)} this month
+      </Text>
+    </Animated.View>
+  );
+}
+

--- a/components/ModeBadge.js
+++ b/components/ModeBadge.js
@@ -1,0 +1,18 @@
+// components/ModeBadge.js
+import React from 'react';
+import { View, Text } from 'react-native';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function ModeBadge({ gameMode, hasEconomicEvents }) {
+  return (
+    <View style={gameStyles.modeSection}>
+      <Text style={gameStyles.modeText}>
+        {gameMode === 'classic' && '📈 Classic Mode'}
+        {gameMode === 'diversified' && '📊 Diversified Mode'}
+        {gameMode === 'speedrun' && '⚡ Speed Run Mode'}
+        {hasEconomicEvents && ' • Economic Events'}
+      </Text>
+    </View>
+  );
+}
+

--- a/components/PortfolioSummary.js
+++ b/components/PortfolioSummary.js
@@ -1,0 +1,27 @@
+// components/PortfolioSummary.js
+import React from 'react';
+import { View, Text, Animated } from 'react-native';
+import { gameStyles } from '../styles/gameStyles';
+
+export default function PortfolioSummary({ formatCurrency, getCurrentPortfolioValue, getBuyHoldValue }) {
+  return (
+    <View style={gameStyles.portfolioSection}>
+      <Text style={gameStyles.sectionTitle}>Your Portfolio</Text>
+      <View style={gameStyles.portfolioGrid}>
+        <View style={gameStyles.portfolioCard}>
+          <Text style={gameStyles.portfolioLabel}>Current Value</Text>
+          <Animated.Text style={gameStyles.portfolioValue}>
+            {formatCurrency(getCurrentPortfolioValue())}
+          </Animated.Text>
+        </View>
+        <View style={gameStyles.portfolioCard}>
+          <Text style={gameStyles.portfolioLabel}>vs Buy & Hold</Text>
+          <Animated.Text style={gameStyles.portfolioValue}>
+            {formatCurrency(getBuyHoldValue())}
+          </Animated.Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+


### PR DESCRIPTION
## Summary
- split GameScreen into dedicated components for progress, market data, portfolio summary, actions, controls, and mode badge
- replace inline sections in `game.js` with the new modular components

## Testing
- `npm test` *(fails: useSettings must be used within a SettingsProvider)*

------
https://chatgpt.com/codex/tasks/task_e_688d78d55b2483309c8137860e0e806b