### PR TITLE
Refactor GameScreen state management and loop

### DIFF
--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,4 @@
+export const INITIAL_CAPITAL = 10000;
+export const ANNUAL_BONUS = 5000;
+export const SPEEDS = { speedrun: 500, classic: 1000 };
+export const DURATIONS = { speedrun: 120, classic: 240 };


### PR DESCRIPTION
## Summary
- streamline game loop with effect-driven side effects and reducer-based portfolios
- derive market values and monthly changes via hooks
- centralize configuration constants

## Testing
- `npm test` *(fails: useSettings must be used within a SettingsProvider)*

------
https://chatgpt.com/codex/tasks/task_e_688d7c108f6c8330bf6dff726545032a