### PR TITLE
fix warning in NewsFlash animation

### DIFF
--- a/components/NewsFlash.js
+++ b/components/NewsFlash.js
@@ -87,8 +87,11 @@ const NewsFlash = ({ event, onDismiss, onBuy, onSell, canBuy, canSell, visible, 
       });
     } else if (!visible) {
       console.log('Resetting animations - not visible');
-      slideAnim.setValue(-200);
-      opacityAnim.setValue(0);
+      // Defer value resets to avoid scheduling updates during render
+      requestAnimationFrame(() => {
+        slideAnim.setValue(-200);
+        opacityAnim.setValue(0);
+      });
     }
   }, [visible, event]);
 


### PR DESCRIPTION
## Summary
- avoid scheduling updates during render when NewsFlash unmounts

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 1 passed, 5 total)*

------
https://chatgpt.com/codex/tasks/task_e_688d87203f9c8330a200e237349a1a50